### PR TITLE
Import plugin directory by default, instead of plugin/init.lua

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -74,7 +74,7 @@ end
 
 -- get path to file
 local get_file_path = function(plug)
-	return plug.path .. '/' .. plug.file .. '.lua'
+	return plug.path .. plug.file .. '.lua'
 end
 
 -- '{http[s]://github.com}/erf/vis-cursors.git'
@@ -147,7 +147,7 @@ end
 
 -- prepare the plug configuration
 local plug_init = function(plug, args)
-	plug.file = plug.file or 'init'
+	plug.file = plug.file and '/' .. plug.file or ''
 	plug.url = get_full_url(plug.url or plug[1])
 	plug.name = get_name_from_url(plug.url)
 	plug.path = get_base_path(plug.theme) .. '/' .. plug.name
@@ -172,7 +172,7 @@ local plug_require = function(plug, args)
 	if plug.theme then
 		return
 	end
-	local name = 'plugins/' .. plug.name .. '/' .. plug.file
+	local name = 'plugins/' .. plug.name .. plug.file
 	local plugin = require(name)
 	if plug.alias then
 		M.plugins[plug.alias] = plugin
@@ -472,7 +472,7 @@ end
 vis.events.subscribe(vis.events.INIT, function()
 	for _, plug in ipairs(plugins_conf) do
 		if plug.theme and file_exists(get_file_path(plug)) then
-			vis:command('set theme ' .. plug.name .. '/' .. plug.file)
+			vis:command('set theme ' .. plug.name .. plug.file)
 			return -- set first theme and return
 		end
 	end


### PR DESCRIPTION
Requiring `plugin.init` instead of `plugin` causes problems with plugins that try to require submodules based on the path they were required from. The plugin that I've found causes this issue is `repo.or.cz/vis-parkour.git`, which will not run without this patch.

This patch shouldn't cause problems with other plugins (that use `init` as their required file) as `init` is the default already when requiring a directory.

This could potentially break backwards compatibility when importing a theme, if the theme file isn't specified explicitly. I'm not sure if there are any themes that use `init.lua` as their filename, and if they would break with this change.